### PR TITLE
Made __global_pointer__ as global hidden symbol

### DIFF
--- a/riscv-compact.md
+++ b/riscv-compact.md
@@ -100,6 +100,7 @@ Functions in shared objects that refer to the global pointer must setup the an a
   ...
   .section .text.__global_pointer__, "aMG", @progbits, 8, __global_pointer__, comdat
   .align 3
+  .global __global_pointer__
   .hidden __global_pointer__
   .type	__global_pointer__, object
 __global_pointer__:


### PR DESCRIPTION
 - local hidden symbol will cause multiple definition for
   `__global_pointer__`.

 - So made `__global_pointer__` as global hidden symbol, it will shared
   same `__global_pointer__` within executable/shared library, but it won't
   expose the symbol to other module.

- Verified on current PoC, it can't work without this change.